### PR TITLE
Update dependabot ignored dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "weekly"
       day: "thursday"
     ignore:
-      - dependency-name: "node"
+      - dependency-name: "@types/node"
         # Ignore 18.x for now since it's not LTS.
         # this will need to be updated manually every so often.
         versions: ["18.x", "19.x"]


### PR DESCRIPTION
## Context

Dependabot is not ignoring `@types/node`, probably because we didn't specify it correctly in `dependabot.yml`

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://agile-poker-qa.superfun.link).

