### PR TITLE
Remove vitest-svelte-kit dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "vite-plugin-windicss": "^1.8.7",
     "vite": "^3.0.5",
     "vitest": "^0.21.1",
-    "vitest-svelte-kit": "^0.0.7",
     "windicss": "^3.5.4"
   },
   "type": "module"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "vite": "^3.0.5",
         "vite-plugin-windicss": "^1.8.7",
         "vitest": "^0.21.1",
-        "vitest-svelte-kit": "^0.0.7",
         "windicss": "^3.5.4"
       }
     },
@@ -5220,13 +5219,6 @@
         }
       }
     },
-    "node_modules/vitest-svelte-kit": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/vitest-svelte-kit/-/vitest-svelte-kit-0.0.7.tgz",
-      "integrity": "sha512-B83C14BAQEwNqTHcZ1dEV9EuCwOEKglcix32zBqRFonTmnc652JUOPJhMDAkQmOzHlA+SIXZ3FNEKiJjXyd1JA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6169,7 +6161,6 @@
         "vite": "^3.0.5",
         "vite-plugin-windicss": "^1.8.7",
         "vitest": "^0.21.1",
-        "vitest-svelte-kit": "^0.0.7",
         "windicss": "^3.5.4"
       },
       "dependencies": {
@@ -9153,12 +9144,6 @@
         "tinyspy": "^1.0.0",
         "vite": "^2.9.12 || ^3.0.0-0"
       }
-    },
-    "vitest-svelte-kit": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/vitest-svelte-kit/-/vitest-svelte-kit-0.0.7.tgz",
-      "integrity": "sha512-B83C14BAQEwNqTHcZ1dEV9EuCwOEKglcix32zBqRFonTmnc652JUOPJhMDAkQmOzHlA+SIXZ3FNEKiJjXyd1JA==",
-      "dev": true
     },
     "webidl-conversions": {
       "version": "7.0.0",


### PR DESCRIPTION
## Context

From the vitest-svelte-kit package:

> This package is no longer necessary nor maintained given that SvelteKit is now exposed as a Vite plugin. To learn more about how to configure Vite – and subsequently Vitest – in SvelteKit, see [here](https://kit.svelte.dev/docs/project-structure#project-files-vite-config-js).

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [ ] All PR checks pass

View the latest [QA deploy](https://agile-poker-qa.superfun.link).

