### PR TITLE
Fix CORS headers for prod

### DIFF
--- a/infra/lib/CorsHeaders.ts
+++ b/infra/lib/CorsHeaders.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent } from "aws-lambda/trigger/api-gateway-proxy";
 
 const localdevOriginRegex = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
-const appDomainRegex = /^https:\/\/agile-poker-(dev|qa|prod)\.superfun\.link$/;
+const appDomainRegex = /^https:\/\/agile-poker(-dev|-qa)?\.superfun\.link$/;
 function isValidDomain(origin: string) {
   return localdevOriginRegex.test(origin) || appDomainRegex.test(origin);
 }

--- a/infra/tests/lib/CorsHeaders.test.ts
+++ b/infra/tests/lib/CorsHeaders.test.ts
@@ -15,7 +15,7 @@ describe("CorsHeaders", () => {
 
   it("allows prod", async () => {
     // Given
-    const event = eventForOrigin("https://agile-poker-prod.superfun.link");
+    const event = eventForOrigin("https://agile-poker.superfun.link");
 
     // When
     const headers = corsAllowApp(event);


### PR DESCRIPTION
## Context

Prod CORS was not working because it was allowing `agile-poker-prod.superfun.link` instead of `agile-poker.superfun.link`.

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [ ] All PR checks pass

View the latest [QA deploy](https://agile-poker-qa.superfun.link).

